### PR TITLE
Add many new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ func main() {
 
 This SDK uses the Balena OData API to retrieve and update data.
 The OData implementation is not generic and mostly geared towards the Balena API.
+It was inspired by the implementation in [gosip](https://github.com/koltyakov/gosip).
 
 ## TODO
 
@@ -84,3 +85,6 @@ The OData implementation is not generic and mostly geared towards the Balena API
 * Implement ID type (i.e. DeviceID, TagID, etc.)
 * More model fields; they are incomplete now.
 * Add code generation for Select(), Filter(), Expand(), etc?
+* Add typesafe handling of OData modifiers (i.e. eq, neq, etc.)
+* Add chaining of multiple subselects (if possible)
+* Add context.Context to requests (in the resources object?)

--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ It was inspired by the implementation in [gosip](https://github.com/koltyakov/go
 * Add typesafe handling of OData modifiers (i.e. eq, neq, etc.)
 * Add chaining of multiple subselects (if possible)
 * Add context.Context to requests (in the resources object?)
+* "Multi-layer" OData modifier handling

--- a/pkg/client/application.go
+++ b/pkg/client/application.go
@@ -23,60 +23,60 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceResource struct {
-	client    *Client
-	endpoint  string
-	deviceID  int
-	modifiers *ODataModifiers
+type ApplicationResource struct {
+	client        *Client
+	endpoint      string
+	applicationID int
+	modifiers     *ODataModifiers
 }
 
-func NewDeviceResource(c *Client, deviceID int) *DeviceResource {
-	return &DeviceResource{
-		client:    c,
-		endpoint:  fmt.Sprintf("%s(%d)", devicesEndpoint, deviceID),
-		deviceID:  deviceID,
-		modifiers: NewODataModifiers(c),
+func NewApplicationResource(c *Client, applicationID int) *ApplicationResource {
+	return &ApplicationResource{
+		client:        c,
+		endpoint:      fmt.Sprintf("%s(%d)", applicationsEndpoint, applicationID),
+		applicationID: applicationID,
+		modifiers:     NewODataModifiers(c),
 	}
 }
 
-func (c *Client) Device(deviceID int) *DeviceResource {
-	return NewDeviceResource(c, deviceID)
+func (c *Client) Application(applicationID int) *ApplicationResource {
+	return NewApplicationResource(c, applicationID)
 }
 
-func (r *DeviceResource) Get() (models.Device, error) {
+func (r *ApplicationResource) Get() (models.Application, error) {
 
-	device := models.Device{}
+	application := models.Application{}
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
 	if err != nil {
-		return device, err
+		return application, err
 	}
 
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 	first := data.Get("0")                   // first (and only) device
 
 	if !first.Exists() {
-		return device, fmt.Errorf("%s not found", r.endpoint)
+		return application, fmt.Errorf("%s not found", r.endpoint)
 	}
 
-	if err := njson.Unmarshal([]byte(first.Raw), &device); err != nil {
-		return device, err
+	if err := njson.Unmarshal([]byte(first.Raw), &application); err != nil {
+		return application, err
 	}
 
-	return device, nil
+	return application, nil
 }
 
-func (r *DeviceResource) Select(s string) *DeviceResource {
+func (r *ApplicationResource) Select(s string) *ApplicationResource {
 	r.modifiers.AddSelect(s) // TODO: add validation that fields to be selected are valid fields for Device?
 	return r
 }
 
-func (r *DeviceResource) Tags() *DeviceTagsResource {
-	tr := NewDeviceTagsResource(
+func (r *ApplicationResource) Tags() *ApplicationTagsResource {
+	tr := NewApplicationTagsResource(
 		r.client,
 	)
 	// TODO: improve the formatting of this filter; Balena API seems to require this like this?
-	tr.modifiers.AddFilter("device/id%20eq%20'" + strconv.Itoa(r.deviceID) + "'")
+	tr.modifiers.AddFilter("application/id%20eq%20'" + strconv.Itoa(r.applicationID) + "'")
 	return tr
 }

--- a/pkg/client/application.go
+++ b/pkg/client/application.go
@@ -80,3 +80,52 @@ func (r *ApplicationResource) Tags() *ApplicationTagsResource {
 	tr.modifiers.AddFilter("application/id%20eq%20'" + strconv.Itoa(r.applicationID) + "'")
 	return tr
 }
+
+func (r *ApplicationResource) Releases() *ReleasesResource {
+	rr := NewReleasesResource(
+		r.client,
+	)
+	filter := "belongs_to__application%20eq%20'" + strconv.Itoa(r.applicationID) + "'"
+	rr.modifiers.AddFilter(filter)
+	return rr
+}
+
+func (r *ApplicationResource) Services() *ServicesResource {
+	sr := NewServicesResource(
+		r.client,
+	)
+	filter := "application/id%20eq%20'" + strconv.Itoa(r.applicationID) + "'"
+	sr.modifiers.AddFilter(filter)
+	return sr
+}
+
+func (r *ApplicationResource) AddTag(key string, value string) (models.ApplicationTag, error) {
+
+	ar := NewApplicationTagsResource(
+		r.client,
+	)
+
+	return ar.Create(r.applicationID, key, value)
+}
+
+func (r *ApplicationResource) UpdateTag(key string, value string) error {
+
+	ar := NewApplicationTagsResource(
+		r.client,
+	)
+
+	ar.modifiers.AddFilter("application/id%20eq%20'" + strconv.Itoa(r.applicationID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return ar.Update(value)
+}
+
+func (r *ApplicationResource) DeleteTag(key string) error {
+
+	ar := NewApplicationTagsResource(
+		r.client,
+	)
+
+	ar.modifiers.AddFilter("application/id%20eq%20'" + strconv.Itoa(r.applicationID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return ar.Delete()
+}

--- a/pkg/client/application_tag.go
+++ b/pkg/client/application_tag.go
@@ -22,29 +22,29 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceTagResource struct {
-	client      *Client
-	endpoint    string
-	deviceTagID int
-	modifiers   *ODataModifiers
+type ApplicationTagResource struct {
+	client           *Client
+	endpoint         string
+	applicationTagID int
+	modifiers        *ODataModifiers
 }
 
-func NewDeviceTagResource(c *Client, deviceTagID int) *DeviceTagResource {
-	return &DeviceTagResource{
-		client:      c,
-		endpoint:    fmt.Sprintf("%s(%d)", deviceTagsEndpoint, deviceTagID),
-		deviceTagID: deviceTagID,
-		modifiers:   NewODataModifiers(c),
+func NewApplicationTagResource(c *Client, applicationTagID int) *ApplicationTagResource {
+	return &ApplicationTagResource{
+		client:           c,
+		endpoint:         fmt.Sprintf("%s(%d)", applicationTagsEndpoint, applicationTagID),
+		applicationTagID: applicationTagID,
+		modifiers:        NewODataModifiers(c),
 	}
 }
 
-func (c *Client) DeviceTag(deviceTagID int) *DeviceTagResource {
-	return NewDeviceTagResource(c, deviceTagID)
+func (c *Client) ApplicationTag(applicationTagID int) *ApplicationTagResource {
+	return NewApplicationTagResource(c, applicationTagID)
 }
 
-func (r *DeviceTagResource) Get() (models.DeviceTag, error) {
+func (r *ApplicationTagResource) Get() (models.ApplicationTag, error) {
 
-	tag := models.DeviceTag{}
+	tag := models.ApplicationTag{}
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
@@ -66,12 +66,12 @@ func (r *DeviceTagResource) Get() (models.DeviceTag, error) {
 	return tag, nil
 }
 
-func (r *DeviceTagResource) Select(s string) *DeviceTagResource {
+func (r *ApplicationTagResource) Select(s string) *ApplicationTagResource {
 	r.modifiers.AddSelect(s)
 	return r
 }
 
-func (r *DeviceTagResource) Expand(s string) *DeviceTagResource {
+func (r *ApplicationTagResource) Expand(s string) *ApplicationTagResource {
 	r.modifiers.AddExpand(s)
 	return r
 }

--- a/pkg/client/application_tags.go
+++ b/pkg/client/application_tags.go
@@ -70,6 +70,56 @@ func (r *ApplicationTagsResource) Get() (map[int]models.ApplicationTag, error) {
 
 }
 
+func (r *ApplicationTagsResource) Create(applicationID int, key string, value string) (models.ApplicationTag, error) {
+
+	tag := models.ApplicationTag{}
+
+	body := map[string]interface{}{
+		"application": applicationID,
+		"tag_key":     key,
+		"value":       value,
+	}
+
+	resp, err := r.client.post(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return tag, err
+	}
+
+	if err := njson.Unmarshal(resp.Body(), &tag); err != nil {
+		return tag, err
+	}
+
+	return tag, nil
+}
+
+func (r *ApplicationTagsResource) Update(value string) error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	body := map[string]interface{}{
+		"value": value,
+	}
+
+	_, err := r.client.patch(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ApplicationTagsResource) Delete() error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	_, err := r.client.delete(r.endpoint, r.modifiers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *ApplicationTagsResource) Select(s string) *ApplicationTagsResource {
 	r.modifiers.AddSelect(s)
 	return r

--- a/pkg/client/application_tags.go
+++ b/pkg/client/application_tags.go
@@ -20,34 +20,34 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceTagsResource struct {
+type ApplicationTagsResource struct {
 	client    *Client
 	endpoint  string
 	modifiers *ODataModifiers
 }
 
-func NewDeviceTagsResource(c *Client) *DeviceTagsResource {
-	return &DeviceTagsResource{
+func NewApplicationTagsResource(c *Client) *ApplicationTagsResource {
+	return &ApplicationTagsResource{
 		client:    c,
-		endpoint:  string(deviceTagsEndpoint),
+		endpoint:  string(applicationTagsEndpoint),
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) DeviceTags() *DeviceTagsResource {
-	return NewDeviceTagsResource(c)
+func (c *Client) ApplicationTags() *ApplicationTagsResource {
+	return NewApplicationTagsResource(c)
 }
 
-func (r *DeviceTagsResource) FindByID(deviceTagID int) *DeviceTagResource {
-	return NewDeviceTagResource(
+func (r *ApplicationTagsResource) FindByID(applicationTagID int) *ApplicationTagResource {
+	return NewApplicationTagResource(
 		r.client,
-		deviceTagID,
+		applicationTagID,
 	)
 }
 
-func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
+func (r *ApplicationTagsResource) Get() (map[int]models.ApplicationTag, error) {
 
-	tags := make(map[int]models.DeviceTag)
+	tags := make(map[int]models.ApplicationTag)
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
@@ -59,7 +59,7 @@ func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 
 	for _, t := range data.Array() {
-		tag := models.DeviceTag{}
+		tag := models.ApplicationTag{}
 		if err := njson.Unmarshal([]byte(t.Raw), &tag); err != nil {
 			return tags, err // TODO: don't do early return, but just skip this one and aggregate error?
 		}
@@ -70,7 +70,12 @@ func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
 
 }
 
-func (r *DeviceTagsResource) Select(s string) *DeviceTagsResource {
+func (r *ApplicationTagsResource) Select(s string) *ApplicationTagsResource {
 	r.modifiers.AddSelect(s)
+	return r
+}
+
+func (r *ApplicationTagsResource) Filter(s string) *ApplicationTagsResource {
+	r.modifiers.AddFilter(s)
 	return r
 }

--- a/pkg/client/applications.go
+++ b/pkg/client/applications.go
@@ -50,6 +50,11 @@ func (r *ApplicationsResource) Filter(f string) *ApplicationsResource {
 	return r
 }
 
+func (r *ApplicationsResource) All() *ApplicationsResource {
+	r.endpoint = string(allApplicationsEndpoint)
+	return r
+}
+
 func (r *ApplicationsResource) Get() (map[int]models.Application, error) {
 
 	applications := make(map[int]models.Application)

--- a/pkg/client/applications.go
+++ b/pkg/client/applications.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DevicesResource struct {
+type ApplicationsResource struct {
 	client    *Client
 	endpoint  string
 	modifiers *ODataModifiers
@@ -28,54 +28,54 @@ type DevicesResource struct {
 	// TODO: context, configuration
 }
 
-func NewDevicesResource(c *Client) *DevicesResource {
-	return &DevicesResource{
+func NewApplicationsResource(c *Client) *ApplicationsResource {
+	return &ApplicationsResource{
 		client:    c,
-		endpoint:  string(devicesEndpoint),
+		endpoint:  string(applicationsEndpoint),
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) Devices() *DevicesResource {
-	return NewDevicesResource(c)
+func (c *Client) Applications() *ApplicationsResource {
+	return NewApplicationsResource(c)
 }
 
-func (r *DevicesResource) Select(s string) *DevicesResource {
+func (r *ApplicationsResource) Select(s string) *ApplicationsResource {
 	r.modifiers.AddSelect(s)
 	return r
 }
 
-func (r *DevicesResource) Filter(f string) *DevicesResource {
+func (r *ApplicationsResource) Filter(f string) *ApplicationsResource {
 	r.modifiers.AddFilter(f)
 	return r
 }
 
-func (r *DevicesResource) Get() (map[int]models.Device, error) {
+func (r *ApplicationsResource) Get() (map[int]models.Application, error) {
 
-	devices := make(map[int]models.Device)
+	applications := make(map[int]models.Application)
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
 	if err != nil {
-		return devices, err
+		return applications, err
 	}
 
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 
-	for _, d := range data.Array() {
-		device := models.Device{}
-		if err := njson.Unmarshal([]byte(d.Raw), &device); err != nil {
-			return devices, err // TODO: don't do early return, but just skip this one and aggregate error?
+	for _, a := range data.Array() {
+		application := models.Application{}
+		if err := njson.Unmarshal([]byte(a.Raw), &application); err != nil {
+			return applications, err // TODO: don't do early return, but just skip this one and aggregate error?
 		}
-		devices[device.ID] = device
+		applications[application.ID] = application
 	}
 
-	return devices, nil
+	return applications, nil
 }
 
-func (r *DevicesResource) FindByID(deviceID int) *DeviceResource {
-	return NewDeviceResource(
+func (r *ApplicationsResource) FindByID(applicationID int) *ApplicationResource {
+	return NewApplicationResource(
 		r.client,
-		deviceID,
+		applicationID,
 	)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -144,8 +144,8 @@ func (c *Client) patch(url string, modifiers *ODataModifiers, body interface{}) 
 	return c.request(resty.MethodPatch, url, modifiers, body)
 }
 
-func (c *Client) delete(url string) (*resty.Response, error) {
-	return c.request(resty.MethodDelete, url, nil, nil)
+func (c *Client) delete(url string, modifiers *ODataModifiers) (*resty.Response, error) {
+	return c.request(resty.MethodDelete, url, modifiers, nil)
 }
 
 func (c *Client) request(method string, url string, modifiers *ODataModifiers, body interface{}) (*resty.Response, error) {

--- a/pkg/client/device.go
+++ b/pkg/client/device.go
@@ -80,3 +80,34 @@ func (r *DeviceResource) Tags() *DeviceTagsResource {
 	tr.modifiers.AddFilter("device/id%20eq%20'" + strconv.Itoa(r.deviceID) + "'")
 	return tr
 }
+
+func (r *DeviceResource) AddTag(key string, value string) (models.DeviceTag, error) {
+
+	tr := NewDeviceTagsResource(
+		r.client,
+	)
+
+	return tr.Create(r.deviceID, key, value)
+}
+
+func (r *DeviceResource) UpdateTag(key string, value string) error {
+
+	tr := NewDeviceTagsResource(
+		r.client,
+	)
+
+	tr.modifiers.AddFilter("device/id%20eq%20'" + strconv.Itoa(r.deviceID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return tr.Update(value)
+}
+
+func (r *DeviceResource) DeleteTag(key string) error {
+
+	tr := NewDeviceTagsResource(
+		r.client,
+	)
+
+	tr.modifiers.AddFilter("device/id%20eq%20'" + strconv.Itoa(r.deviceID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return tr.Delete()
+}

--- a/pkg/client/device_tag.go
+++ b/pkg/client/device_tag.go
@@ -66,6 +66,31 @@ func (r *DeviceTagResource) Get() (models.DeviceTag, error) {
 	return tag, nil
 }
 
+func (r *DeviceTagResource) Update(value string) error {
+
+	body := map[string]interface{}{
+		"value": value,
+	}
+
+	_, err := r.client.patch(r.endpoint, r.modifiers, body)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *DeviceTagResource) Delete() error {
+
+	_, err := r.client.delete(r.endpoint, r.modifiers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *DeviceTagResource) Select(s string) *DeviceTagResource {
 	r.modifiers.AddSelect(s)
 	return r

--- a/pkg/client/device_tags.go
+++ b/pkg/client/device_tags.go
@@ -70,7 +70,62 @@ func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
 
 }
 
+func (r *DeviceTagsResource) Create(deviceID int, key string, value string) (models.DeviceTag, error) {
+
+	tag := models.DeviceTag{}
+
+	body := map[string]interface{}{
+		"device":  deviceID,
+		"tag_key": key,
+		"value":   value,
+	}
+
+	resp, err := r.client.post(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return tag, err
+	}
+
+	if err := njson.Unmarshal(resp.Body(), &tag); err != nil {
+		return tag, err
+	}
+
+	return tag, nil
+}
+
+func (r *DeviceTagsResource) Update(value string) error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	body := map[string]interface{}{
+		"value": value,
+	}
+
+	_, err := r.client.patch(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *DeviceTagsResource) Delete() error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	_, err := r.client.delete(r.endpoint, r.modifiers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *DeviceTagsResource) Select(s string) *DeviceTagsResource {
 	r.modifiers.AddSelect(s)
+	return r
+}
+
+func (r *DeviceTagsResource) Filter(s string) *DeviceTagsResource {
+	r.modifiers.AddFilter(s)
 	return r
 }

--- a/pkg/client/odata.go
+++ b/pkg/client/odata.go
@@ -29,7 +29,7 @@ type ODataModifiers struct {
 	errors    []error
 }
 
-func (c *Client) NewODataModifiers() *ODataModifiers {
+func NewODataModifiers(c *Client) *ODataModifiers {
 	return &ODataModifiers{
 		modifiers: map[modifierOption]string{},
 		logger:    c.logger,

--- a/pkg/client/release.go
+++ b/pkg/client/release.go
@@ -23,60 +23,60 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceResource struct {
+type ReleaseResource struct {
 	client    *Client
 	endpoint  string
-	deviceID  int
+	releaseID int
 	modifiers *ODataModifiers
 }
 
-func NewDeviceResource(c *Client, deviceID int) *DeviceResource {
-	return &DeviceResource{
+func NewReleaseResource(c *Client, releaseID int) *ReleaseResource {
+	return &ReleaseResource{
 		client:    c,
-		endpoint:  fmt.Sprintf("%s(%d)", devicesEndpoint, deviceID),
-		deviceID:  deviceID,
+		endpoint:  fmt.Sprintf("%s(%d)", releasesEndpoint, releaseID),
+		releaseID: releaseID,
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) Device(deviceID int) *DeviceResource {
-	return NewDeviceResource(c, deviceID)
+func (c *Client) Release(releaseID int) *ReleaseResource {
+	return NewReleaseResource(c, releaseID)
 }
 
-func (r *DeviceResource) Get() (models.Device, error) {
+func (r *ReleaseResource) Get() (models.Release, error) {
 
-	device := models.Device{}
+	release := models.Release{}
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
 	if err != nil {
-		return device, err
+		return release, err
 	}
 
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 	first := data.Get("0")                   // first (and only) device
 
 	if !first.Exists() {
-		return device, fmt.Errorf("%s not found", r.endpoint)
+		return release, fmt.Errorf("%s not found", r.endpoint)
 	}
 
-	if err := njson.Unmarshal([]byte(first.Raw), &device); err != nil {
-		return device, err
+	if err := njson.Unmarshal([]byte(first.Raw), &release); err != nil {
+		return release, err
 	}
 
-	return device, nil
+	return release, nil
 }
 
-func (r *DeviceResource) Select(s string) *DeviceResource {
+func (r *ReleaseResource) Select(s string) *ReleaseResource {
 	r.modifiers.AddSelect(s) // TODO: add validation that fields to be selected are valid fields for Device?
 	return r
 }
 
-func (r *DeviceResource) Tags() *DeviceTagsResource {
-	tr := NewDeviceTagsResource(
+func (r *ReleaseResource) Tags() *ReleaseTagsResource {
+	tr := NewReleaseTagsResource(
 		r.client,
 	)
 	// TODO: improve the formatting of this filter; Balena API seems to require this like this?
-	tr.modifiers.AddFilter("device/id%20eq%20'" + strconv.Itoa(r.deviceID) + "'")
+	tr.modifiers.AddFilter("release/id%20eq%20'" + strconv.Itoa(r.releaseID) + "'")
 	return tr
 }

--- a/pkg/client/release.go
+++ b/pkg/client/release.go
@@ -80,3 +80,34 @@ func (r *ReleaseResource) Tags() *ReleaseTagsResource {
 	tr.modifiers.AddFilter("release/id%20eq%20'" + strconv.Itoa(r.releaseID) + "'")
 	return tr
 }
+
+func (r *ReleaseResource) AddTag(key string, value string) (models.ReleaseTag, error) {
+
+	tr := NewReleaseTagsResource(
+		r.client,
+	)
+
+	return tr.Create(r.releaseID, key, value)
+}
+
+func (r *ReleaseResource) UpdateTag(key string, value string) error {
+
+	tr := NewReleaseTagsResource(
+		r.client,
+	)
+
+	tr.modifiers.AddFilter("release/id%20eq%20'" + strconv.Itoa(r.releaseID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return tr.Update(value)
+}
+
+func (r *ReleaseResource) DeleteTag(key string) error {
+
+	tr := NewReleaseTagsResource(
+		r.client,
+	)
+
+	tr.modifiers.AddFilter("release/id%20eq%20'" + strconv.Itoa(r.releaseID) + "'%20and%20tag_key%20eq%20'" + key + "'")
+
+	return tr.Delete()
+}

--- a/pkg/client/release_tag.go
+++ b/pkg/client/release_tag.go
@@ -22,29 +22,29 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceTagResource struct {
-	client      *Client
-	endpoint    string
-	deviceTagID int
-	modifiers   *ODataModifiers
+type ReleaseTagResource struct {
+	client       *Client
+	endpoint     string
+	releaseTagID int
+	modifiers    *ODataModifiers
 }
 
-func NewDeviceTagResource(c *Client, deviceTagID int) *DeviceTagResource {
-	return &DeviceTagResource{
-		client:      c,
-		endpoint:    fmt.Sprintf("%s(%d)", deviceTagsEndpoint, deviceTagID),
-		deviceTagID: deviceTagID,
-		modifiers:   NewODataModifiers(c),
+func NewReleaseTagResource(c *Client, releaseTagID int) *ReleaseTagResource {
+	return &ReleaseTagResource{
+		client:       c,
+		endpoint:     fmt.Sprintf("%s(%d)", releaseTagsEndpoint, releaseTagID),
+		releaseTagID: releaseTagID,
+		modifiers:    NewODataModifiers(c),
 	}
 }
 
-func (c *Client) DeviceTag(deviceTagID int) *DeviceTagResource {
-	return NewDeviceTagResource(c, deviceTagID)
+func (c *Client) ReleaseTag(releaseTagID int) *ReleaseTagResource {
+	return NewReleaseTagResource(c, releaseTagID)
 }
 
-func (r *DeviceTagResource) Get() (models.DeviceTag, error) {
+func (r *ReleaseTagResource) Get() (models.ReleaseTag, error) {
 
-	tag := models.DeviceTag{}
+	tag := models.ReleaseTag{}
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
@@ -66,12 +66,12 @@ func (r *DeviceTagResource) Get() (models.DeviceTag, error) {
 	return tag, nil
 }
 
-func (r *DeviceTagResource) Select(s string) *DeviceTagResource {
+func (r *ReleaseTagResource) Select(s string) *ReleaseTagResource {
 	r.modifiers.AddSelect(s)
 	return r
 }
 
-func (r *DeviceTagResource) Expand(s string) *DeviceTagResource {
+func (r *ReleaseTagResource) Expand(s string) *ReleaseTagResource {
 	r.modifiers.AddExpand(s)
 	return r
 }

--- a/pkg/client/release_tags.go
+++ b/pkg/client/release_tags.go
@@ -20,34 +20,34 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DeviceTagsResource struct {
+type ReleaseTagsResource struct {
 	client    *Client
 	endpoint  string
 	modifiers *ODataModifiers
 }
 
-func NewDeviceTagsResource(c *Client) *DeviceTagsResource {
-	return &DeviceTagsResource{
+func NewReleaseTagsResource(c *Client) *ReleaseTagsResource {
+	return &ReleaseTagsResource{
 		client:    c,
-		endpoint:  string(deviceTagsEndpoint),
+		endpoint:  string(releaseTagsEndpoint),
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) DeviceTags() *DeviceTagsResource {
-	return NewDeviceTagsResource(c)
+func (c *Client) ReleaseTags() *ReleaseTagsResource {
+	return NewReleaseTagsResource(c)
 }
 
-func (r *DeviceTagsResource) FindByID(deviceTagID int) *DeviceTagResource {
-	return NewDeviceTagResource(
+func (r *ReleaseTagsResource) FindByID(releaseTagID int) *ReleaseTagResource {
+	return NewReleaseTagResource(
 		r.client,
-		deviceTagID,
+		releaseTagID,
 	)
 }
 
-func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
+func (r *ReleaseTagsResource) Get() (map[int]models.ReleaseTag, error) {
 
-	tags := make(map[int]models.DeviceTag)
+	tags := make(map[int]models.ReleaseTag)
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
@@ -59,7 +59,7 @@ func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 
 	for _, t := range data.Array() {
-		tag := models.DeviceTag{}
+		tag := models.ReleaseTag{}
 		if err := njson.Unmarshal([]byte(t.Raw), &tag); err != nil {
 			return tags, err // TODO: don't do early return, but just skip this one and aggregate error?
 		}
@@ -70,7 +70,12 @@ func (r *DeviceTagsResource) Get() (map[int]models.DeviceTag, error) {
 
 }
 
-func (r *DeviceTagsResource) Select(s string) *DeviceTagsResource {
+func (r *ReleaseTagsResource) Select(s string) *ReleaseTagsResource {
 	r.modifiers.AddSelect(s)
+	return r
+}
+
+func (r *ReleaseTagsResource) Filter(s string) *ReleaseTagsResource {
+	r.modifiers.AddFilter(s)
 	return r
 }

--- a/pkg/client/release_tags.go
+++ b/pkg/client/release_tags.go
@@ -70,6 +70,56 @@ func (r *ReleaseTagsResource) Get() (map[int]models.ReleaseTag, error) {
 
 }
 
+func (r *ReleaseTagsResource) Create(releaseID int, key string, value string) (models.ReleaseTag, error) {
+
+	tag := models.ReleaseTag{}
+
+	body := map[string]interface{}{
+		"release": releaseID,
+		"tag_key": key,
+		"value":   value,
+	}
+
+	resp, err := r.client.post(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return tag, err
+	}
+
+	if err := njson.Unmarshal(resp.Body(), &tag); err != nil {
+		return tag, err
+	}
+
+	return tag, nil
+}
+
+func (r *ReleaseTagsResource) Update(value string) error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	body := map[string]interface{}{
+		"value": value,
+	}
+
+	_, err := r.client.patch(r.endpoint, r.modifiers, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReleaseTagsResource) Delete() error {
+
+	// TODO: should modifiers (also) be handled here?
+
+	_, err := r.client.delete(r.endpoint, r.modifiers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *ReleaseTagsResource) Select(s string) *ReleaseTagsResource {
 	r.modifiers.AddSelect(s)
 	return r

--- a/pkg/client/releases.go
+++ b/pkg/client/releases.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DevicesResource struct {
+type ReleasesResource struct {
 	client    *Client
 	endpoint  string
 	modifiers *ODataModifiers
@@ -28,54 +28,54 @@ type DevicesResource struct {
 	// TODO: context, configuration
 }
 
-func NewDevicesResource(c *Client) *DevicesResource {
-	return &DevicesResource{
+func NewReleasesResource(c *Client) *ReleasesResource {
+	return &ReleasesResource{
 		client:    c,
-		endpoint:  string(devicesEndpoint),
+		endpoint:  string(releasesEndpoint),
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) Devices() *DevicesResource {
-	return NewDevicesResource(c)
+func (c *Client) Releases() *ReleasesResource {
+	return NewReleasesResource(c)
 }
 
-func (r *DevicesResource) Select(s string) *DevicesResource {
+func (r *ReleasesResource) Select(s string) *ReleasesResource {
 	r.modifiers.AddSelect(s)
 	return r
 }
 
-func (r *DevicesResource) Filter(f string) *DevicesResource {
+func (r *ReleasesResource) Filter(f string) *ReleasesResource {
 	r.modifiers.AddFilter(f)
 	return r
 }
 
-func (r *DevicesResource) Get() (map[int]models.Device, error) {
+func (r *ReleasesResource) Get() (map[int]models.Release, error) {
 
-	devices := make(map[int]models.Device)
+	releases := make(map[int]models.Release)
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
 	if err != nil {
-		return devices, err
+		return releases, err
 	}
 
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 
-	for _, d := range data.Array() {
-		device := models.Device{}
-		if err := njson.Unmarshal([]byte(d.Raw), &device); err != nil {
-			return devices, err // TODO: don't do early return, but just skip this one and aggregate error?
+	for _, r := range data.Array() {
+		release := models.Release{}
+		if err := njson.Unmarshal([]byte(r.Raw), &release); err != nil {
+			return releases, err // TODO: don't do early return, but just skip this one and aggregate error?
 		}
-		devices[device.ID] = device
+		releases[release.ID] = release
 	}
 
-	return devices, nil
+	return releases, nil
 }
 
-func (r *DevicesResource) FindByID(deviceID int) *DeviceResource {
-	return NewDeviceResource(
+func (r *ReleasesResource) FindByID(releaseID int) *ReleaseResource {
+	return NewReleaseResource(
 		r.client,
-		deviceID,
+		releaseID,
 	)
 }

--- a/pkg/client/services.go
+++ b/pkg/client/services.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type DevicesResource struct {
+type ServicesResource struct {
 	client    *Client
 	endpoint  string
 	modifiers *ODataModifiers
@@ -28,54 +28,54 @@ type DevicesResource struct {
 	// TODO: context, configuration
 }
 
-func NewDevicesResource(c *Client) *DevicesResource {
-	return &DevicesResource{
+func NewServicesResource(c *Client) *ServicesResource {
+	return &ServicesResource{
 		client:    c,
-		endpoint:  string(devicesEndpoint),
+		endpoint:  string(servicesEndpoint),
 		modifiers: NewODataModifiers(c),
 	}
 }
 
-func (c *Client) Devices() *DevicesResource {
-	return NewDevicesResource(c)
+func (c *Client) Services() *ServicesResource {
+	return NewServicesResource(c)
 }
 
-func (r *DevicesResource) Select(s string) *DevicesResource {
+func (r *ServicesResource) Select(s string) *ServicesResource {
 	r.modifiers.AddSelect(s)
 	return r
 }
 
-func (r *DevicesResource) Filter(f string) *DevicesResource {
+func (r *ServicesResource) Filter(f string) *ServicesResource {
 	r.modifiers.AddFilter(f)
 	return r
 }
 
-func (r *DevicesResource) Get() (map[int]models.Device, error) {
+func (r *ServicesResource) Get() (map[int]models.Service, error) {
 
-	devices := make(map[int]models.Device)
+	services := make(map[int]models.Service)
 
 	resp, err := r.client.get(r.endpoint, r.modifiers)
 
 	if err != nil {
-		return devices, err
+		return services, err
 	}
 
 	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
 
-	for _, d := range data.Array() {
-		device := models.Device{}
-		if err := njson.Unmarshal([]byte(d.Raw), &device); err != nil {
-			return devices, err // TODO: don't do early return, but just skip this one and aggregate error?
+	for _, s := range data.Array() {
+		service := models.Service{}
+		if err := njson.Unmarshal([]byte(s.Raw), &service); err != nil {
+			return services, err // TODO: don't do early return, but just skip this one and aggregate error?
 		}
-		devices[device.ID] = device
+		services[service.ID] = service
 	}
 
-	return devices, nil
+	return services, nil
 }
 
-func (r *DevicesResource) FindByID(deviceID int) *DeviceResource {
-	return NewDeviceResource(
+func (r *ServicesResource) FindByID(serviceID int) *ServiceResource {
+	return NewServiceResource(
 		r.client,
-		deviceID,
+		serviceID,
 	)
 }

--- a/pkg/client/users.go
+++ b/pkg/client/users.go
@@ -1,0 +1,99 @@
+// Copyright 2020 Herman Slatman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/hslatman/balena-sdk-go/pkg/models"
+	"github.com/m7shapan/njson"
+	"github.com/tidwall/gjson"
+)
+
+type UsersResource struct {
+	client    *Client
+	endpoint  string
+	modifiers *ODataModifiers
+
+	// TODO: context, configuration
+}
+
+func NewUsersResource(c *Client) *UsersResource {
+	return &UsersResource{
+		client:    c,
+		endpoint:  string(usersEndpoint),
+		modifiers: NewODataModifiers(c),
+	}
+}
+
+func (c *Client) Users() *UsersResource {
+	return NewUsersResource(c)
+}
+
+func (c *Client) WhoAmI() (models.WhoAmI, error) {
+
+	w := models.WhoAmI{}
+
+	url := "https://api.balena-cloud.com/user/v1" // This endpoint uses a different format than all other v5 APIs
+	resp, err := c.get(url+string(whoamiEndpoint), nil)
+
+	if err != nil {
+		return w, err
+	}
+
+	if err := njson.Unmarshal(resp.Body(), &w); err != nil {
+		return w, err
+	}
+
+	return w, nil
+}
+
+func (r *UsersResource) Select(s string) *UsersResource {
+	r.modifiers.AddSelect(s)
+	return r
+}
+
+func (r *UsersResource) Filter(f string) *UsersResource {
+	r.modifiers.AddFilter(f)
+	return r
+}
+
+func (r *UsersResource) Get() (map[int]models.User, error) {
+
+	users := make(map[int]models.User)
+
+	resp, err := r.client.get(r.endpoint, r.modifiers)
+
+	if err != nil {
+		return users, err
+	}
+
+	data := gjson.GetBytes(resp.Body(), "d") // get data; a list of results
+
+	for _, u := range data.Array() {
+		user := models.User{}
+		if err := njson.Unmarshal([]byte(u.Raw), &user); err != nil {
+			return users, err // TODO: don't do early return, but just skip this one and aggregate error?
+		}
+		users[user.ID] = user
+	}
+
+	return users, nil
+}
+
+func (r *UsersResource) FindByID(userID int) *UserResource {
+	return NewUserResource(
+		r.client,
+		userID,
+	)
+}

--- a/pkg/client/users.go
+++ b/pkg/client/users.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"strconv"
+
 	"github.com/hslatman/balena-sdk-go/pkg/models"
 	"github.com/m7shapan/njson"
 	"github.com/tidwall/gjson"
@@ -56,6 +58,18 @@ func (c *Client) WhoAmI() (models.WhoAmI, error) {
 	}
 
 	return w, nil
+}
+
+func (r *UsersResource) AssociatedWithApplication(applicationID int) *UsersResource {
+
+	// TODO: this could end up in errors when more actions are applied fluently
+	r.endpoint = r.endpoint + "__is_member_of__application"
+	r.modifiers.AddFilter("is_member_of__application%20eq%20'" + strconv.Itoa(applicationID) + "'")
+	r.modifiers.AddExpand("user($select=id,username,actor),application_membership_role($select=id,name,actor)")
+
+	// TODO: the values returned are also a bit weird, because there's a list and in there there's an object ...
+
+	return r
 }
 
 func (r *UsersResource) Select(s string) *UsersResource {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -63,7 +63,7 @@ func (l ExampleLogger) Log(v ...interface{}) {
 }
 
 func (l ExampleLogger) Logf(format string, v ...interface{}) {
-	fmt.Println(fmt.Sprintf(format, v))
+	fmt.Println(fmt.Sprintf(format, v...))
 }
 
 func (l ExampleLogger) Info(message string) {

--- a/pkg/models/application.go
+++ b/pkg/models/application.go
@@ -15,11 +15,11 @@
 package models
 
 type Application struct {
-	ID         int    `json:"id"`
-	Name       string `json:"app_name"`
-	Slug       string `json:"slug"`
-	DeviceType string `json:"device_type"`
-	IsPublic   bool   `json:"is_public"`
-	IsHost     bool   `json:"is_host"`
-	IsArchived bool   `json:"is_archived"`
+	ID         int    `njson:"id"`
+	Name       string `njson:"app_name"`
+	Slug       string `njson:"slug"`
+	DeviceType string `njson:"device_type"`
+	IsPublic   bool   `njson:"is_public"`
+	IsHost     bool   `njson:"is_host"`
+	IsArchived bool   `njson:"is_archived"`
 }

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -15,10 +15,10 @@
 package models
 
 type Device struct {
-	ID   int    `json:"id"`
-	Name string `json:"device_name"`
-	Type string `json:"device_type"`
-	UUID string `json:"uuid"`
+	ID   int    `njson:"id"`
+	Name string `njson:"device_name"`
+	Type string `njson:"device_type"`
+	UUID string `njson:"uuid"`
 
 	// TODO: other fields
 }

--- a/pkg/models/release.go
+++ b/pkg/models/release.go
@@ -17,14 +17,14 @@ package models
 import "time"
 
 type Release struct {
-	ID              int       `json:"id"`
-	Commit          string    `json:"commit"`
-	Status          string    `json:"status"`
-	Source          string    `json:"source"`
-	CreatedAt       time.Time `json:"created_at"`
-	StartTimestamp  time.Time `json:"start_timestamp"`
-	EndTimestamp    time.Time `json:"end_timestamp"`
-	UpdateTimestamp time.Time `json:"update_timestamp"`
+	ID              int       `njson:"id"`
+	Commit          string    `njson:"commit"`
+	Status          string    `njson:"status"`
+	Source          string    `njson:"source"`
+	CreatedAt       time.Time `njson:"created_at"`
+	StartTimestamp  time.Time `njson:"start_timestamp"`
+	EndTimestamp    time.Time `njson:"end_timestamp"`
+	UpdateTimestamp time.Time `njson:"update_timestamp"`
 }
 
 // id

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -14,8 +14,11 @@
 
 package models
 
+import "time"
+
 type User struct {
-	ID       int    `json:"id"`
-	Actor    int    `json:"actor"`
-	Username string `json:"username"`
+	ID        int       `njson:"id"`
+	Actor     int       `njson:"actor"`
+	Username  string    `njson:"username"`
+	CreatedAt time.Time `njson:"created_at"`
 }

--- a/pkg/models/whoami.go
+++ b/pkg/models/whoami.go
@@ -15,7 +15,7 @@
 package models
 
 type WhoAmI struct {
-	ID       int    `json:"id"`
-	EMail    string `json:"email"`
-	Username string `json:"username"`
+	ID       int    `njson:"id"`
+	EMail    string `njson:"email"`
+	Username string `njson:"username"`
 }


### PR DESCRIPTION
This PR includes a more complete rewrite of the SDK. It now uses a somewhat more generic way for handling OData queries inspired by the approach in [gosip](https://github.com/koltyakov/gosip). The implementation is not complete nor ideal yet, but basic queries are already possible using this implementation.

Newly added resources include Users, Device Tags, Release Tags, Applications, Services and Releases. There are also some new convenience methods for handling certain operations, like adding or updating a Device Tag belonging to a Device.